### PR TITLE
fix(shlib): Fix bugs in shlib.path.to_absolute

### DIFF
--- a/bash-bundler/bin/bash-bundler
+++ b/bash-bundler/bin/bash-bundler
@@ -3585,10 +3585,18 @@ shlib.path.to_absolute() {
 	local -r path=$1
 	local -r relativeBase=${2:-$PWD}
 
+	if ! shlib.path.is_absolute "$relativeBase"; then
+		return 1
+	fi
 	if shlib.path.is_absolute "$path"; then
 		echo "$path"
+		return 0
 	fi
-	echo "$relativeBase/$path"
+	if [[ ${relativeBase: -1} == / ]]; then
+		echo "$relativeBase$path"
+	else
+		echo "$relativeBase/$path"
+	fi
 }
 
 shlib.path.resolve() {

--- a/media-scripts/bin/m4a-to-mp3
+++ b/media-scripts/bin/m4a-to-mp3
@@ -3609,10 +3609,18 @@ shlib.path.to_absolute() {
 	local -r path=$1
 	local -r relativeBase=${2:-$PWD}
 
+	if ! shlib.path.is_absolute "$relativeBase"; then
+		return 1
+	fi
 	if shlib.path.is_absolute "$path"; then
 		echo "$path"
+		return 0
 	fi
-	echo "$relativeBase/$path"
+	if [[ ${relativeBase: -1} == / ]]; then
+		echo "$relativeBase$path"
+	else
+		echo "$relativeBase/$path"
+	fi
 }
 
 shlib.path.resolve() {

--- a/media-scripts/bin/merge-video-and-audio
+++ b/media-scripts/bin/merge-video-and-audio
@@ -3609,10 +3609,18 @@ shlib.path.to_absolute() {
 	local -r path=$1
 	local -r relativeBase=${2:-$PWD}
 
+	if ! shlib.path.is_absolute "$relativeBase"; then
+		return 1
+	fi
 	if shlib.path.is_absolute "$path"; then
 		echo "$path"
+		return 0
 	fi
-	echo "$relativeBase/$path"
+	if [[ ${relativeBase: -1} == / ]]; then
+		echo "$relativeBase$path"
+	else
+		echo "$relativeBase/$path"
+	fi
 }
 
 shlib.path.resolve() {

--- a/media-scripts/bin/pic-is-portrait-fullhd
+++ b/media-scripts/bin/pic-is-portrait-fullhd
@@ -3612,10 +3612,18 @@ shlib.path.to_absolute() {
 	local -r path=$1
 	local -r relativeBase=${2:-$PWD}
 
+	if ! shlib.path.is_absolute "$relativeBase"; then
+		return 1
+	fi
 	if shlib.path.is_absolute "$path"; then
 		echo "$path"
+		return 0
 	fi
-	echo "$relativeBase/$path"
+	if [[ ${relativeBase: -1} == / ]]; then
+		echo "$relativeBase$path"
+	else
+		echo "$relativeBase/$path"
+	fi
 }
 
 shlib.path.resolve() {

--- a/media-scripts/bin/pic-to-portrait-fullhd
+++ b/media-scripts/bin/pic-to-portrait-fullhd
@@ -3609,10 +3609,18 @@ shlib.path.to_absolute() {
 	local -r path=$1
 	local -r relativeBase=${2:-$PWD}
 
+	if ! shlib.path.is_absolute "$relativeBase"; then
+		return 1
+	fi
 	if shlib.path.is_absolute "$path"; then
 		echo "$path"
+		return 0
 	fi
-	echo "$relativeBase/$path"
+	if [[ ${relativeBase: -1} == / ]]; then
+		echo "$relativeBase$path"
+	else
+		echo "$relativeBase/$path"
+	fi
 }
 
 shlib.path.resolve() {

--- a/shlib/src/path/potpourri.shlib.path.to_absolute.bash
+++ b/shlib/src/path/potpourri.shlib.path.to_absolute.bash
@@ -4,8 +4,16 @@ shlib.path.to_absolute() {
 	local -r path=$1
 	local -r relativeBase=${2:-$PWD}
 
+	if ! shlib.path.is_absolute "$relativeBase"; then
+		return 1
+	fi
 	if shlib.path.is_absolute "$path"; then
 		echo "$path"
+		return 0
 	fi
-	echo "$relativeBase/$path"
+	if [[ ${relativeBase: -1} == / ]]; then
+		echo "$relativeBase$path"
+	else
+		echo "$relativeBase/$path"
+	fi
 }


### PR DESCRIPTION
- check relativeBase is absolute path, else error
- fix two line output when path already absolute
- support following slash in relativeBase
- rebuild all dependent packages