### PR TITLE
test(shlib): Add tests for shlib.path.to_absolute

### DIFF
--- a/shlib/test/assert/file_exist.bats
+++ b/shlib/test/assert/file_exist.bats
@@ -3,13 +3,13 @@
 @test "assert.file_exist: real file" {
 	source potpourri.shlib.assert.file_exist.bash
 
-	shlib.assert.file_exist test/fixtures/assert/file_exist/foo.txt
+	( shlib.assert.file_exist test/fixtures/assert/file_exist/foo.txt )
 }
 
 @test "assert.file_exist: symlink to real file" {
 	source potpourri.shlib.assert.file_exist.bash
 
-	shlib.assert.file_exist test/fixtures/assert/file_exist/foo1.txt
+	( shlib.assert.file_exist test/fixtures/assert/file_exist/foo1.txt )
 }
 
 @test "assert.file_exist: broken symlink ; prints an error" {

--- a/shlib/test/path/to_absolute.bats
+++ b/shlib/test/path/to_absolute.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+@test "path.to_absolute: /foo/bar" {
+	source potpourri.shlib.path.to_absolute.bash
+
+	run shlib.path.to_absolute /foo/bar
+
+	[[ $status == 0 ]]
+	[[ $output == "/foo/bar" ]]
+}
+
+@test "path.to_absolute: foo/bar" {
+	source potpourri.shlib.path.to_absolute.bash
+
+	run shlib.path.to_absolute foo/bar
+
+	[[ $status == 0 ]]
+	[[ $output == "$PWD/foo/bar" ]]
+}
+
+@test "path.to_absolute: foo/bar, relativeBase='/'" {
+	source potpourri.shlib.path.to_absolute.bash
+
+	run shlib.path.to_absolute foo/bar '/'
+
+	[[ $status == 0 ]]
+	[[ $output == "/foo/bar" ]]
+}
+
+@test "path.to_absolute: foo/bar, relativeBase='/baz'" {
+	source potpourri.shlib.path.to_absolute.bash
+
+	run shlib.path.to_absolute foo/bar '/baz'
+
+	[[ $status == 0 ]]
+	[[ $output == "/baz/foo/bar" ]]
+}
+
+@test "path.to_absolute: foo/bar, relativeBase='qux' ; returns an error code" {
+	source potpourri.shlib.path.to_absolute.bash
+
+	run shlib.path.to_absolute foo/bar 'qux'
+
+	[[ $status == 1 ]]
+}


### PR DESCRIPTION
- run shlib.assert.file_exist tests in subshell to catch exit