### PR TITLE
ci(hyperborea): Don`t build twice the same commit

### DIFF
--- a/tools/cfg/cspell.json
+++ b/tools/cfg/cspell.json
@@ -59,6 +59,7 @@
 		"shellcheckrc",
 		"shfmt",
 		// real words:
+		"interruptible",
 		"unmounting",
 		"unshift",
 		"untracked",

--- a/tools/cfg/gitlab-ci.yaml
+++ b/tools/cfg/gitlab-ci.yaml
@@ -8,6 +8,7 @@ stages:
 
 commit-lint:
   stage: commit-lint
+  interruptible: true
   script:
     - git fetch origin master:master --depth 50
     - >
@@ -18,12 +19,15 @@ commit-lint:
 
 style-lint:
   stage: style-lint
+  interruptible: true
   script: nix-shell --run style-lint
 
 test:
   stage: test
+  interruptible: true
   script: nix-shell --command 'makeall test'
 
 static-analysis:
   stage: static-analysis
+  interruptible: true
   script: nix-shell --run static-analysis


### PR DESCRIPTION
- enable 'interruptible' in gitlab-ci.yaml
- enable 'Auto-cancel pending pipelines' in CI/CD Settings of Hyperborea in gitlab.com
- enable Potpourri-bot for this repo, see Potpourri/HubLabBot#10
- add word 'interruptible' to cSpell dictionary