### PR TITLE
ci(hyperborea): Speed up GitLab CI

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Nikita Belyakov
+Copyright (c) 2019-2020 Nikita Belyakov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tools/cfg/gitlab-ci.yaml
+++ b/tools/cfg/gitlab-ci.yaml
@@ -2,9 +2,7 @@ image: registry.gitlab.com/potpourri1/hyperborea
 
 stages:
   - commit-lint
-  - style-lint
-  - test
-  - static-analysis
+  - code-lint-or-test
 
 commit-lint:
   stage: commit-lint
@@ -18,16 +16,37 @@ commit-lint:
         bashfnx potpourri.gitlib.assert_all_committed'
 
 style-lint:
-  stage: style-lint
+  stage: code-lint-or-test
   interruptible: true
   script: nix-shell --run style-lint
+  rules:
+    - changes:
+      - "*/src/**/*"
+      - "*/makefile"
+      - tools/cfg/hyperborea.mk
+      - tools/style-lint
+      - tools/cfg/cspell.json
 
 test:
-  stage: test
+  stage: code-lint-or-test
   interruptible: true
   script: nix-shell --command 'makeall test'
+  rules:
+    - changes:
+      - "*/src/**/*"
+      - "*/test/**/*"
+      - "*/makefile"
+      - tools/cfg/hyperborea.mk
 
 static-analysis:
-  stage: static-analysis
+  stage: code-lint-or-test
   interruptible: true
   script: nix-shell --run static-analysis
+  rules:
+    - changes:
+      - "*/src/**/*"
+      - "*/makefile"
+      - tools/cfg/hyperborea.mk
+      - tools/static-analysis
+      - .shellcheckrc
+      - tools/cfg/jscpd.json


### PR DESCRIPTION
- replace stages 'style-lint', 'test', 'static-analysis' with
  one 'code-lint-or-test'
- jobs 'style-lint', 'test', 'static-analysis' are now in
  'code-lint-or-test' stage
- jobs 'style-lint', 'test', 'static-analysis' now run in parallel
- jobs 'style-lint', 'test', 'static-analysis' now run only if used
  files have been changed
- update copyright in LICENSE