### PR TITLE
feat(nix-shell2docker): Run nix-shell automatically inside container

### DIFF
--- a/nix-shell2docker/bin/nix-shell2docker
+++ b/nix-shell2docker/bin/nix-shell2docker
@@ -3771,13 +3771,13 @@ declare -r IMAGE="$DOCKER_REGISTRY_URL${DOCKER_REGISTRY_USER:?}/$PROJECT_NAME"
 declare -r NIX_VERSION=${NIX_VERSION:-2.2.1}
 
 build() {
-	local tmpDir dockerfile
+	local tmpDir dockerCxt
 
 	tmpDir=$(mktemp -d)
 	cd "$PROJECT_ROOT"
 
-	dockerfile="$(shlib.sys.get_real_scriptdir)/../share/nix-shell2docker/Dockerfile"
-	cp -r "$dockerfile" shell.nix tools/cfg/nix/ "$tmpDir"
+	dockerCxt="$(shlib.sys.get_real_scriptdir)/../share/nix-shell2docker"
+	cp -r "$dockerCxt/Dockerfile" "$dockerCxt/nix-shell-wrapper" tools/cfg/nix/ "$tmpDir"
 	mkdir -p tools/log
 	docker build --tag "$IMAGE" \
 		--build-arg NIX_VERSION="$NIX_VERSION" \

--- a/nix-shell2docker/share/nix-shell2docker/Dockerfile
+++ b/nix-shell2docker/share/nix-shell2docker/Dockerfile
@@ -17,20 +17,21 @@ password sufficient pam_unix.so nullok sha512\n\
 session required pam_unix.so' \
 > /etc/pam.d/sudo
 
-COPY shell.nix /root/
+COPY nix-shell-wrapper /usr/bin/
 COPY nix/ /root/tools/cfg/nix/
 
 RUN set -o nounset \
 	&& echo -e "\n-- Building shell.nix\n" \
 	&& cd /root \
 	&& mkdir -p .gcroots \
-	&& nix-instantiate shell.nix --indirect --add-root "$PWD/.gcroots/shell.drv" \
+	&& nix-instantiate tools/cfg/nix/shell.nix --indirect --add-root "$PWD/.gcroots/shell.drv" \
 	&& deps="$(nix-store --query --references "$PWD/.gcroots/shell.drv")" \
 	&& nix-store --indirect --add-root "$PWD/.gcroots/shell.dep" --realise $deps \
 	&& nix-collect-garbage --delete-old \
 	&& nix-shell .gcroots/shell.drv --run exit \
-	&& nix-store --optimise \
-	&& rm -r /root/shell.nix /root/tools/cfg/nix/
+	&& nix-store --optimise
 
-WORKDIR /root
-CMD ["nix-shell", ".gcroots/shell.drv"]
+ENV CI_PROJECT_DIR /root
+WORKDIR $CI_PROJECT_DIR
+ENTRYPOINT ["/usr/bin/nix-shell-wrapper"]
+CMD ["exec bash"]

--- a/nix-shell2docker/share/nix-shell2docker/nix-shell-wrapper
+++ b/nix-shell2docker/share/nix-shell2docker/nix-shell-wrapper
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -o errexit -o nounset -o pipefail
+
+main() {
+	if [ "$1" = -c ]; then
+		shift
+	fi
+
+	exec nix-shell "$CI_PROJECT_DIR/tools/cfg/nix/shell.nix" --command "$1"
+}
+
+main "$@"

--- a/nix-shell2docker/src/nix-shell2docker
+++ b/nix-shell2docker/src/nix-shell2docker
@@ -35,13 +35,13 @@ declare -r IMAGE="$DOCKER_REGISTRY_URL${DOCKER_REGISTRY_USER:?}/$PROJECT_NAME"
 declare -r NIX_VERSION=${NIX_VERSION:-2.2.1}
 
 build() {
-	local tmpDir dockerfile
+	local tmpDir dockerCxt
 
 	tmpDir=$(mktemp -d)
 	cd "$PROJECT_ROOT"
 
-	dockerfile="$(shlib.sys.get_real_scriptdir)/../share/nix-shell2docker/Dockerfile"
-	cp -r "$dockerfile" shell.nix tools/cfg/nix/ "$tmpDir"
+	dockerCxt="$(shlib.sys.get_real_scriptdir)/../share/nix-shell2docker"
+	cp -r "$dockerCxt/Dockerfile" "$dockerCxt/nix-shell-wrapper" tools/cfg/nix/ "$tmpDir"
 	mkdir -p tools/log
 	docker build --tag "$IMAGE" \
 		--build-arg NIX_VERSION="$NIX_VERSION" \


### PR DESCRIPTION
- `WORKDIR` now refers to env var `CI_PROJECT_DIR`, default: `/root`